### PR TITLE
Fix empty subdirectories under the output path

### DIFF
--- a/src/latexformat/utils.py
+++ b/src/latexformat/utils.py
@@ -21,10 +21,6 @@ def is_empty_generator(generator: typing.Generator) -> bool:
     return next(generator, dummy) is dummy
 
 
-def is_empty_directory(directory: Path) -> bool:
-    return is_empty_generator(directory.iterdir())
-
-
 def files_have_same_contents(file: Path, base_file: Path) -> bool:
     return filecmp.cmp(str(file), str(base_file))
 


### PR DESCRIPTION
Fixes #1.

Previously we simply saved each formatted file to the appropriate path under the output directory and then checked if that file is different from the original. If it was, we removed the newly created file and its directory (provided that it was empty).

Now we follow a different approach. Specifically, we create a temporary file, compare it to the original, and only then copy this temporary file to the desired destination. This way, we ensure that we never create a directory that would later become empty.