### PR TITLE
Resolve path to directory in `search_parents_for_file`

### DIFF
--- a/src/latexformat/utils.py
+++ b/src/latexformat/utils.py
@@ -7,6 +7,7 @@ import sys
 def search_parents_for_file(
     file_name: str, directory: Path
 ) -> typing.Optional[Path]:
+    directory = directory.resolve()
     while True:
         guess = directory / file_name
         if guess.is_file():


### PR DESCRIPTION
There was a minor bug in the `search_parents_for_file` helper function (from `utils.py`). Specifically, instead of going up until the actual root of the file system, it was going up only until the end of the specified `directory` path. For instance, for `directory='.'`, the function would search only the current directory `.` and then stop.

One consequence of this bug was that `latexformat` couldn't find the `latexindent.yaml` settings file if it was located in one of the parents of the current directory `.`.

The bug is now fixed by calling `directory.resolve()` before doing the actual search.