### PR TITLE
Add `-r` flag to `latexindent` for applying replacement rules

### DIFF
--- a/src/latexformat/formatting.py
+++ b/src/latexformat/formatting.py
@@ -27,6 +27,7 @@ def run_latexindent(
         "-g",
         path_to_null_device(),
         "-m",
+        "-r"
     ]
 
     if settings_path is None:


### PR DESCRIPTION
Ensure that `latexindent` applies replacement rules specified in the `latexindent.yaml` configuration file.