### PR TITLE
Fix URLs in `pyproject.toml` and installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ installed on your system.
 # Installation
 
 ```shell
-pipx install https://github.com/arodomanov/latexformat/tarball/master
+pipx install git+https://github.com/arodomanov/latexformat.git@v0.1.3
 ```
 
 # Update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,5 +21,5 @@ classifiers = [
 latexformat = "latexformat.cli:main"
 
 [project.urls]
-"Homepage" = "https://github.com/arodomanov/preliminary-latex-format"
-"Bug Tracker" = "https://github.com/arodomanov/preliminary-latex-format/issues"
+"Homepage" = "https://github.com/arodomanov/latexformat"
+"Bug Tracker" = "https://github.com/arodomanov/latexformat/issues"


### PR DESCRIPTION
- Correct the "Home page" and "Bug tracker" URLs in the `pyproject.toml` file.

- Update the installation command in the README to use a specific version (`v0.1.3`) of the package, aligning with best practices for installing stable and predictable releases.